### PR TITLE
Changé le lien du site dans le README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <p align="center">
     Site officiel de l’initiative Students 4 Students.
     <br />
-    <a href="https://students-4-students.github.io/"><strong>Voir le site »</strong></a>
+    <a href="https://s4s.fun/"><strong>Voir le site »</strong></a>
   </p>
 </p>
 


### PR DESCRIPTION
Le lien pointait vers la page github.io, maintenant terminée. Cette PR le remplace par https://s4s.fun/.